### PR TITLE
Fix Android Build Error across Different Drives

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+kotlin.incremental=false


### PR DESCRIPTION
Disables Kotlin incremental compilation to fix IllegalArgumentException: this and base files have different roots when project is on a different drive than pub cache.