### PR TITLE
Implement Back Navigation for Menu Pages (Fixes #7)

### DIFF
--- a/lib/presentation/pages/billing_page.dart
+++ b/lib/presentation/pages/billing_page.dart
@@ -1,13 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class BillingPage extends StatelessWidget {
   const BillingPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Billing')),
-      body: const Center(child: Text('Halaman Billing')),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        if (didPop) return;
+        context.go('/');
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Billing'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              context.go('/');
+            },
+          ),
+        ),
+        body: const Center(child: Text('Halaman Billing')),
+      ),
     );
   }
 }

--- a/lib/presentation/pages/product_page.dart
+++ b/lib/presentation/pages/product_page.dart
@@ -1,13 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class ProductPage extends StatelessWidget {
   const ProductPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Product')),
-      body: const Center(child: Text('Halaman Product')),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        if (didPop) return;
+        context.go('/');
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Product'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              context.go('/');
+            },
+          ),
+        ),
+        body: const Center(child: Text('Halaman Product')),
+      ),
     );
   }
 }

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -1,13 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
-      body: const Center(child: Text('Halaman Settings')),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        if (didPop) return;
+        context.go('/');
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Settings'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              context.go('/');
+            },
+          ),
+        ),
+        body: const Center(child: Text('Halaman Settings')),
+      ),
     );
   }
 }

--- a/lib/presentation/pages/shop_page.dart
+++ b/lib/presentation/pages/shop_page.dart
@@ -1,13 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class ShopPage extends StatelessWidget {
   const ShopPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Shop')),
-      body: const Center(child: Text('Halaman Shop')),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        if (didPop) return;
+        context.go('/');
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Shop'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              context.go('/');
+            },
+          ),
+        ),
+        body: const Center(child: Text('Halaman Shop')),
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR implements the back navigation logic as described in Issue #7. It adds AppBar leading arrow buttons and handles system back button events using PopScope to ensure users are redirected back to the Home page from Billing, Product, Settings, and Shop pages.